### PR TITLE
Added graphql builder for easy generate query strings

### DIFF
--- a/src/main/kotlin/com/monday/graphql/Arg.kt
+++ b/src/main/kotlin/com/monday/graphql/Arg.kt
@@ -1,0 +1,7 @@
+package com.monday.graphql
+
+class Arg {
+    var name: String? = null
+    var type: Type? = null
+    var value: String? = null
+}

--- a/src/main/kotlin/com/monday/graphql/Field.kt
+++ b/src/main/kotlin/com/monday/graphql/Field.kt
@@ -1,0 +1,103 @@
+package com.monday.graphql
+
+import java.lang.StringBuilder
+
+class Field {
+    var name: String? = null
+    var args: List<Arg> = listOf()
+    var selectedFields: List<Field> = listOf()
+
+    class Builder {
+        var name : String? = null
+        var args: MutableList<Arg> = mutableListOf()
+        var selectedFields : MutableList<Field> = mutableListOf()
+
+        fun withName(name: String): Builder {
+            this.name = name
+            return this
+        }
+
+        fun withArg(name: String, value: String): Builder {
+            args.add(Arg().apply {
+                this.name = name
+                this.value = value
+            })
+
+            return this
+        }
+
+        fun withArg(name: String, value: Int): Builder {
+            args.add(Arg().apply {
+                this.name = name
+                this.value = value.toString()
+            })
+
+            return this
+        }
+
+        fun withArg(name: String, value: Float): Builder {
+            args.add(Arg().apply {
+                this.name = name
+                this.value = value.toString()
+            })
+
+            return this
+        }
+
+        fun withArg(name: String, value: Boolean): Builder {
+            args.add(Arg().apply {
+                this.name = name
+                this.value = value.toString()
+            })
+
+            return this
+        }
+
+        fun selectField(name: String): Builder {
+            selectedFields.add(Field().apply { this.name = name })
+            return this
+        }
+
+        fun selectField(name: String, block: (Builder) -> Unit): Builder {
+            val fieldBuilder = Field.Builder().withName(name)
+            fieldBuilder.apply(block)
+            selectedFields.add(fieldBuilder.build())
+            return this
+        }
+
+        fun build() =
+            Field().apply {
+                name = this@Builder.name
+                args = this@Builder.args
+                selectedFields = this@Builder.selectedFields
+            }
+    }
+
+    fun asString(): String {
+        val builder = StringBuilder()
+        builder.append(this.name)
+        if (args.isNotEmpty()) {
+            builder.append("(")
+            for (i in args.indices) {
+                val arg = args[i]
+                builder.append("${arg.name}: ${arg.value!!}")
+                if (i < args.size - 1)
+                    builder.append(", ")
+            }
+            builder.append(")")
+        }
+
+        if (selectedFields.isNotEmpty()) {
+            builder.append(" { ")
+            for (i in selectedFields.indices) {
+                val field = selectedFields[i]
+                builder.append(field.asString())
+                if (i < selectedFields.size - 1)
+                    builder.append(" ")
+            }
+            builder.append(" }")
+        }
+
+        return builder.toString()
+    }
+}

--- a/src/main/kotlin/com/monday/graphql/Mutation.kt
+++ b/src/main/kotlin/com/monday/graphql/Mutation.kt
@@ -1,0 +1,56 @@
+package com.monday.graphql
+
+class Mutation {
+    public var name: String? = null
+    public var rootField: Field? = null
+
+    public class Builder {
+        private var name: String? = null
+        private var rootField: Field? = null
+
+        fun withRootField(name: String): Mutation.Builder {
+            return withRootField(name) { }
+        }
+
+        fun withRootField(name: String, block: (Field.Builder) -> Unit): Mutation.Builder {
+            val fieldBuilder = Field.Builder().withName(name)
+            fieldBuilder.apply(block)
+            rootField = fieldBuilder.build()
+            return this
+        }
+
+        fun withRootField(field: Field): Mutation.Builder {
+            rootField = field
+            return this
+        }
+
+        fun withName(name: String): Builder {
+            this.name = name
+            return this
+        }
+
+        fun build() =
+            Mutation().apply {
+                name = this@Builder.name
+                rootField = this@Builder.rootField
+            }
+    }
+
+    override fun toString(): String {
+        val builder = StringBuilder()
+
+        builder.append("mutation ")
+
+        name?.let {
+            builder.append("$it ")
+        }
+
+        builder.append("{ ")
+        builder.append(rootField!!.asString())
+        if (rootField!!.selectedFields.isEmpty())
+            builder.append("{ }")
+        builder.append(" }")
+
+        return builder.toString()
+    }
+}

--- a/src/main/kotlin/com/monday/graphql/Query.kt
+++ b/src/main/kotlin/com/monday/graphql/Query.kt
@@ -1,0 +1,56 @@
+package com.monday.graphql
+
+class Query {
+    public var name: String? = null
+    public var rootField: Field? = null
+
+    public class Builder {
+        private var name: String? = null
+        private var rootField: Field? = null
+
+        fun withRootField(name: String): Query.Builder {
+            return withRootField(name) { }
+        }
+
+        fun withRootField(name: String, block: (Field.Builder) -> Unit): Query.Builder {
+            val fieldBuilder = Field.Builder().withName(name)
+            fieldBuilder.apply(block)
+            rootField = fieldBuilder.build()
+            return this
+        }
+
+        fun withRootField(field: Field): Query.Builder {
+            rootField = field
+            return this
+        }
+
+        fun withName(name: String): Builder {
+            this.name = name
+            return this
+        }
+
+        fun build() =
+            Query().apply {
+                name = this@Builder.name
+                rootField = this@Builder.rootField
+            }
+    }
+
+    override fun toString(): String {
+        val builder = StringBuilder()
+
+        builder.append("query ")
+
+        name?.let {
+            builder.append("$it ")
+        }
+
+        builder.append("{ ")
+        builder.append(rootField!!.asString())
+        if (rootField!!.selectedFields.isEmpty())
+            builder.append("{ }")
+        builder.append(" }")
+
+        return builder.toString()
+    }
+}

--- a/src/main/kotlin/com/monday/graphql/Type.kt
+++ b/src/main/kotlin/com/monday/graphql/Type.kt
@@ -1,0 +1,6 @@
+package com.monday.graphql
+
+class Type {
+    var name: String? = null
+    var nullable = false
+}

--- a/src/main/kotlin/com/monday/graphql/Value.kt
+++ b/src/main/kotlin/com/monday/graphql/Value.kt
@@ -1,0 +1,5 @@
+package com.monday.graphql
+
+abstract class Value<T>(val value: T) {
+    abstract fun asString(): String
+}

--- a/src/main/kotlin/com/monday/graphql/dsl/invoke.kt
+++ b/src/main/kotlin/com/monday/graphql/dsl/invoke.kt
@@ -1,0 +1,57 @@
+package com.monday.graphql.dsl
+
+import com.monday.graphql.Field
+import com.monday.graphql.Mutation
+import com.monday.graphql.Query
+
+operator fun String.invoke(block: Field.Builder.() -> Unit): Field.Builder {
+    val builder = Field.Builder()
+    builder.block()
+    return builder.withName(this)
+}
+
+operator fun <T> String.invoke(vararg args: Pair<String, T>, block: (Field.Builder.() -> Unit)? = null): Field.Builder {
+    val builder = Field.Builder().withName(this)
+    for (arg in args)
+        when (arg.second) {
+            is String -> builder.withArg(arg.first, arg.second as String)
+            is Int -> builder.withArg(arg.first, arg.second as Int)
+            is Float -> builder.withArg(arg.first, arg.second as Float)
+            is Boolean -> builder.withArg(arg.first, arg.second as Boolean)
+            else -> throw IllegalArgumentException("Unsupported argument type for ${arg.first}: ${arg.second}")
+        }
+
+    if (block != null)
+        builder.block()
+    return builder
+}
+
+fun Field.Builder.select(name: String) = selectField(name)
+
+inline fun Field.Builder.select(name: String, block: Field.Builder.() -> Unit): Field.Builder {
+    val fieldBuilder = Field.Builder().withName(name)
+    fieldBuilder.block()
+    selectedFields.add(fieldBuilder.build())
+    return this
+}
+
+fun Field.Builder.select(fieldBuilder: Field.Builder): Field.Builder {
+    selectedFields.add(fieldBuilder.build())
+    return this
+}
+
+inline fun query(name: String? = null, block: () -> Field.Builder): Query {
+    val queryBuilder = Query.Builder()
+    if (name != null) {
+        queryBuilder.withName(name)
+    }
+    return queryBuilder.withRootField(block().build()).build()
+}
+
+inline fun mutation(name: String? = null, block: () -> Field.Builder): Mutation {
+    val mutationBuilder = Mutation.Builder()
+    if (name != null) {
+        mutationBuilder.withName(name)
+    }
+    return mutationBuilder.withRootField(block().build()).build()
+}


### PR DESCRIPTION
How to use -
```
query {
        "users"("limit" to 10) {
            select("name")
            select("id")
            select("email")
        }
    }
```

```
mutation {
        "create_group"("board_id" to 1234, "group_name" to "Group1") {
            select("id")
            select("title")

        }
    }
```